### PR TITLE
Remove log4j

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,6 +16,17 @@
             <groupId>com.github.wenweihu86.raft</groupId>
             <artifactId>raft-java-core</artifactId>
             <version>1.8.0</version>
+            <!--exclude log4j in raft-brpc-core-->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/test/src/main/resources/logback.xml
+++ b/test/src/main/resources/logback.xml
@@ -39,7 +39,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.dst.server">
+    <logger name="org.dst.test">
         <level value="info"/>
     </logger>
 


### PR DESCRIPTION
Exclude the redundant slf4j binding in `raft-java-core`.